### PR TITLE
修复新增空骨骼映射时blender终端报错的问题

### DIFF
--- a/data.py
+++ b/data.py
@@ -8,7 +8,7 @@ class BAC_BoneMapping(bpy.types.PropertyGroup):
         # 更改自身骨骼，需要先清空旧的约束再生成新的约束
         self.clear()
         self.owner = self.selected_owner
-        if len(self.get_owner().constraints) > 0:
+        if self.get_owner() != None and len(self.get_owner().constraints) > 0:
             alert_error('所选骨骼上包含其它约束', '本插件所生成的约束(名称以BAC开头)若与其它约束混用，可能导致烘焙效果出现偏差。建议避免映射这根骨骼')
         self.apply()
 


### PR DESCRIPTION
有空骨骼映射时，`BAC_BoneMapping.get_owner()`会返回`None`，尝试读取`None`的`constraints`会在blender的终端报错

> Traceback (most recent call last):
>   File ".\blender_BoneAnimCopy\data.py", line 11, in update_owner
>     if len(self.get_owner().constraints) > 0:
> AttributeError: 'NoneType' object has no attribute 'constraints'
> File ".\blender_BoneAnimCopy\data.py", line 7, in update_owner

此pull request就是加了一层检查而已