### PR TITLE
修复F3控制台报错以及override对象无法使用插件的问题

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -95,26 +95,28 @@ class BAC_State(bpy.types.PropertyGroup):
     
     selected_target: bpy.props.PointerProperty(
         type=bpy.types.Object,
+        override={'LIBRARY_OVERRIDABLE'},
         poll=lambda self, obj: obj.type == 'ARMATURE' and obj != bpy.context.scene.kumopult_bac_owner,
         update=update_target
     )
-    target: bpy.props.PointerProperty(type=bpy.types.Object)
-    owner: bpy.props.PointerProperty(type=bpy.types.Object)
+    target: bpy.props.PointerProperty(type=bpy.types.Object, override={'LIBRARY_OVERRIDABLE'})
+    owner: bpy.props.PointerProperty(type=bpy.types.Object, override={'LIBRARY_OVERRIDABLE'})
     
-    mappings: bpy.props.CollectionProperty(type=data.BAC_BoneMapping)
-    active_mapping: bpy.props.IntProperty(default=-1, update=update_active)
-    selected_count:bpy.props.IntProperty(default=0, update=update_select)
+    mappings: bpy.props.CollectionProperty(type=data.BAC_BoneMapping, override={'LIBRARY_OVERRIDABLE', 'USE_INSERTION'})
+    active_mapping: bpy.props.IntProperty(default=-1, override={'LIBRARY_OVERRIDABLE'}, update=update_active)
+    selected_count:bpy.props.IntProperty(default=0, override={'LIBRARY_OVERRIDABLE'}, update=update_select)
     
-    editing_type: bpy.props.IntProperty(description="用于记录面板类型")
+    editing_type: bpy.props.IntProperty(description="用于记录面板类型", override={'LIBRARY_OVERRIDABLE'})
     preview: bpy.props.BoolProperty(
         default=True, 
         description="开关所有约束以便预览烘培出的动画之类的",
+        override={'LIBRARY_OVERRIDABLE'},
         update=update_preview
     )
 
-    sync_select: bpy.props.BoolProperty(default=False, name='同步选择', description="点击列表项时会自动激活相应骨骼\n勾选列表项时会自动选中相应骨骼")
-    calc_offset: bpy.props.BoolProperty(default=True, name='自动旋转偏移', description="设定映射目标时自动计算旋转偏移")
-    ortho_offset: bpy.props.BoolProperty(default=True, name='正交', description="将计算结果近似至90°的倍数")
+    sync_select: bpy.props.BoolProperty(default=False, name='同步选择', description="点击列表项时会自动激活相应骨骼\n勾选列表项时会自动选中相应骨骼", override={'LIBRARY_OVERRIDABLE'})
+    calc_offset: bpy.props.BoolProperty(default=True, name='自动旋转偏移', description="设定映射目标时自动计算旋转偏移", override={'LIBRARY_OVERRIDABLE'})
+    ortho_offset: bpy.props.BoolProperty(default=True, name='正交', description="将计算结果近似至90°的倍数", override={'LIBRARY_OVERRIDABLE'})
     
     def get_target_armature(self):
         return self.target.data
@@ -196,7 +198,7 @@ def register():
     for cls in classes:
         bpy.utils.register_class(cls)
     bpy.types.Scene.kumopult_bac_owner = bpy.props.PointerProperty(type=bpy.types.Object, poll=lambda self, obj: obj.type == 'ARMATURE')
-    bpy.types.Armature.kumopult_bac = bpy.props.PointerProperty(type=BAC_State)
+    bpy.types.Armature.kumopult_bac = bpy.props.PointerProperty(type=BAC_State, override={'LIBRARY_OVERRIDABLE'})
     print("hello kumopult!")
 
 def unregister():

--- a/data.py
+++ b/data.py
@@ -77,28 +77,33 @@ class BAC_BoneMapping(bpy.types.PropertyGroup):
     selected_owner: bpy.props.StringProperty(
         name="自身骨骼", 
         description="将对方骨骼的旋转复制到自身的哪根骨骼上？", 
+        override={'LIBRARY_OVERRIDABLE'},
         update=update_owner
     )
-    owner: bpy.props.StringProperty()
+    owner: bpy.props.StringProperty(override={'LIBRARY_OVERRIDABLE'})
     target: bpy.props.StringProperty(
         name="约束目标", 
-        description="从对方骨架中选择哪根骨骼作为约束目标？", 
+        description="从对方骨架中选择哪根骨骼作为约束目标？",
+        override={'LIBRARY_OVERRIDABLE'},
         update=update_target
     )
 
     has_rotoffs: bpy.props.BoolProperty(
         name="旋转偏移", 
-        description="附加额外约束，从而在原变换结果的基础上进行额外的旋转", 
+        description="附加额外约束，从而在原变换结果的基础上进行额外的旋转",
+        override={'LIBRARY_OVERRIDABLE'},
         update=update_rotoffs
     )
     has_loccopy: bpy.props.BoolProperty(
         name="位置映射", 
-        description="附加额外约束，从而使目标骨骼跟随原骨骼的世界坐标运动，通常应用于根骨骼、武器等", 
+        description="附加额外约束，从而使目标骨骼跟随原骨骼的世界坐标运动，通常应用于根骨骼、武器等",
+        override={'LIBRARY_OVERRIDABLE'},
         update=update_loccopy
     )
     has_ik: bpy.props.BoolProperty(
         name="IK",
         description="附加额外约束，从而使目标骨骼跟随原骨骼进行IK矫正，通常应用于手掌、脚掌",
+        override={'LIBRARY_OVERRIDABLE'},
         update=update_ik
     )
 
@@ -107,12 +112,14 @@ class BAC_BoneMapping(bpy.types.PropertyGroup):
         description="世界坐标下复制旋转方向后，在那基础上进行的额外旋转偏移。通常只需要调整Y旋转", 
         min=-pi,
         max=pi,
+        override={'LIBRARY_OVERRIDABLE'},
         subtype='EULER',
         update=update_rotoffs
     )
     loc_axis: bpy.props.BoolVectorProperty(
         name="位置映射轴向",
         default=[True, True, True],
+        override={'LIBRARY_OVERRIDABLE'},
         update=update_loccopy
     )
     ik_influence: bpy.props.FloatProperty(
@@ -120,13 +127,14 @@ class BAC_BoneMapping(bpy.types.PropertyGroup):
         default=1,
         min=0,
         max=1,
+        override={'LIBRARY_OVERRIDABLE'},
         update=update_ik
     )
 
     def update_selected(self, context):
         get_state().selected_count += 1 if self.selected else -1
     
-    selected: bpy.props.BoolProperty(update=update_selected)
+    selected: bpy.props.BoolProperty(override={'LIBRARY_OVERRIDABLE'}, update=update_selected)
 
     
     def get_owner(self):

--- a/mapping.py
+++ b/mapping.py
@@ -163,7 +163,7 @@ class BAC_OT_SelectEditType(bpy.types.Operator):
     bl_description = '选择编辑列表类型'
     bl_options = {'UNDO'}
 
-    selected_type: bpy.props.IntProperty()
+    selected_type: bpy.props.IntProperty(override={'LIBRARY_OVERRIDABLE'})
 
     def execute(self, context):
         s = get_state()
@@ -177,7 +177,7 @@ class BAC_OT_SelectAction(bpy.types.Operator):
     bl_description = '全选/弃选/反选'
     bl_options = {'UNDO'}
 
-    action: bpy.props.StringProperty()
+    action: bpy.props.StringProperty(override={'LIBRARY_OVERRIDABLE'})
 
     def execute(self, context):
         s = get_state()
@@ -214,7 +214,7 @@ class BAC_OT_ListAction(bpy.types.Operator):
     bl_description = '依次为新建、删除、上移、下移\n其中在姿态模式下选中骨骼并点击新建的话，\n可以自动填入对应骨骼'
     bl_options = {'UNDO'}
 
-    action: bpy.props.StringProperty()
+    action: bpy.props.StringProperty(override={'LIBRARY_OVERRIDABLE'})
 
     def execute(self, context):
         s = get_state()
@@ -294,12 +294,14 @@ class BAC_OT_ChildMapping(bpy.types.Operator):
     bl_description = '如果选中映射的目标骨骼和自身骨骼都有且仅有唯一的子级，则在那两个子级间建立新的映射'
     bl_options = {'UNDO'}
     
-    execute_flag: bpy.props.BoolProperty(default=False)
+    execute_flag: bpy.props.BoolProperty(default=False, override={'LIBRARY_OVERRIDABLE'})
 
     @classmethod
     def poll(cls, context):
         ret = True
         s = get_state()
+        if s == None:
+            return False
         for i in s.get_selection():
             if not s.mappings[i].is_valid():
                 ret = False
@@ -344,6 +346,8 @@ class BAC_OT_NameMapping(bpy.types.Operator):
     def poll(cls, context):
         ret = True
         s = get_state()
+        if s == None:
+            return False
         for i in s.get_selection():
             if s.mappings[i].get_owner() == None:
                 ret = False
@@ -376,12 +380,14 @@ class BAC_OT_MirrorMapping(bpy.types.Operator):
     bl_description = '如果选中映射的目标骨骼和自身骨骼都有与之对称的骨骼，则在那两个对称骨骼间建立新的映射'
     bl_options = {'UNDO'}
 
-    execute_flag: bpy.props.BoolProperty(default=False)
+    execute_flag: bpy.props.BoolProperty(default=False, override={'LIBRARY_OVERRIDABLE'})
 
     @classmethod
     def poll(cls, context):
         ret = True
         s = get_state()
+        if s == None:
+            return False
         for i in s.get_selection():
             if not s.mappings[i].is_valid():
                 ret = False

--- a/utilfuncs.py
+++ b/utilfuncs.py
@@ -1,6 +1,8 @@
 import bpy
 
 def get_state():
+    if bpy.context.scene.kumopult_bac_owner == None:
+        return None
     return bpy.context.scene.kumopult_bac_owner.data.kumopult_bac
 
 def set_enable(con: bpy.types.Constraint, state):


### PR DESCRIPTION
此变动修复两个问题：
1. #5 

解决方案：对`get_state()`和三个`Operator`的`poll()`方法都加了一层检查

2. 当`映射骨架`为从其他blender文件链接进来并创建的`override`对象时（设该对象的`data`为`bpy.data.armatures["Override"]`），`约束目标`无法被指定。

造成问题2的原因是`约束目标`是`BAC_State`类的一个属性，`kumopult_bac`属于`BAC_State`类，`kumopult_bac`被注册为`Armature`下面的一个属性，因此要修改`约束目标`就要访问`bpy.data.armatures["Override"].kumopult_bac.selected_target`。

当外部的`Armature`数据被链接进来时，`Armature`类下面所有没有被标记为`override={'LIBRARY_OVERRIDABLE'}`的`Property`都无法在用户界面修改，即使对其进行`override`也一样。因此`bpy.data.armatures["Override"].kumopult_bac.selected_target`无法被覆写，进而导致`约束目标`无法被指定。

解决方案：将插件里面所有`Armature`下面定义的`Property`都加上一个`override={'LIBRARY_OVERRIDABLE'}`标签，对于`CollectionProperty`还得加上`'USE_INSERTION'`。